### PR TITLE
Fix : `first` function is not defined

### DIFF
--- a/ts.el
+++ b/ts.el
@@ -255,7 +255,7 @@ e.g. `ts-fill'."
 
                      (--map (list (intern (concat ":" (symbol-name (car it))))
                                   (cddr it)))))
-         (keywords (-map #'first slots))
+         (keywords (-map #'car slots))
          (constructors (->> slots
                             (--map (plist-get (cadr it) :constructor))
                             -non-nil))


### PR DESCRIPTION
```
ELISP> (require 'ts)
*** Eval error ***  Symbol’s function definition is void: first
```