### PR TITLE
Tests: Fix ideal value for leap year length in seconds being off

### DIFF
--- a/test/test.el
+++ b/test/test.el
@@ -442,8 +442,8 @@
     ;; these two values, depending on whether a leap day is involved.
     ;; FIXME: I guess this test will fail if a leap second is involved.  If that
     ;; ever actually causes the test to fail, it should be easy to fix then.
-    (should (or (equal 31536000 (floor (ts-difference ts one-year-ago)))
-                (equal 31622399 (floor (ts-difference ts one-year-ago)))))))
+    (should (or (equal (* 60 60 24 365) (floor (ts-difference ts one-year-ago)))
+                (equal (* 60 60 24 366) (floor (ts-difference ts one-year-ago)))))))
 
 ;;;; Footer
 


### PR DESCRIPTION
https://github.com/alphapapa/ts.el/blob/df48734ef046547c1aa0de0f4c07d11964ef1f7f/test/test.el#L445-L446

Although the test doesn't take leap seconds into account, a normal leap year should still be 31622400 (60 seconds * 60 minutes * 24 hours * 366 days) seconds long.