### PR TITLE
Parse timestamps into a TS

### DIFF
--- a/test/test.el
+++ b/test/test.el
@@ -339,6 +339,25 @@
     ;; 12:12, which means 0 seconds.
     (should (eq (ts-S ts) 0))))
 
+(ert-deftest ts-parse-timestamp ()
+  ;; common cases for second resolution
+  (should (equal 0 (ts-unix (ts-parse-timestamp 0))))
+  (should (equal 123 (ts-unix (ts-parse-timestamp 123))))
+  (should (equal -123 (ts-unix (ts-parse-timestamp -123))))
+  (should (equal 123.456 (ts-unix (ts-parse-timestamp 123.456))))
+  ;; normalization
+  (should (equal 123.456 (ts-unix (ts-parse-timestamp 123456 'milli))))
+  (should (equal 123.456789 (ts-unix (ts-parse-timestamp 123456789 'nano))))
+  (should (equal 123.456789012 (ts-unix (ts-parse-timestamp 123456789012 'pico))))
+  ;; normalization works even if timestamp is already a float
+  (should (equal 123.456789 (ts-unix (ts-parse-timestamp 123456.789 'milli))))
+  ;; string conversion
+  (should (equal 123 (ts-unix (ts-parse-timestamp "123"))))
+  (should (equal 123.456 (ts-unix (ts-parse-timestamp "123456" 'milli))))
+  (should (equal 123.456789 (ts-unix (ts-parse-timestamp "123456.789" 'milli))))
+  ;; we cannot test different epochs yet since there is only unix epoch defined
+  )
+
 (ert-deftest ts-parse-org ()
   ;; NOTE: Not sure how to best handle loading `org-parse-time-string'.  Calling (require 'ts)
   ;; shouldn't cause Org to be loaded, so the user will probably have to do that.

--- a/ts.el
+++ b/ts.el
@@ -296,6 +296,27 @@ filled to \"12:12:00\", not \"12:12:59\"."
          float-time
          (make-ts :unix))))
 
+(cl-defsubst ts-parse-timestamp (timestamp &optional (resolution 'second) (epoch 'unix))
+  "Return a TS constructed from TIMESTAMP.
+Essentially: (make-ts :unix (+ normalized-timestamp ts-epoch(epoch)))
+
+* TIMESTAMP must be numberp-or-stringp. It defines the offset
+  from the EPOCH (default 'unix) in RESOLUTION (default 'second)
+* RESOLUTION (optional, default 'second) specifies the resolution of the
+  timestamp. One of: 'second, 'milli, 'nano, 'pico.
+* EPOCH (optional, default 'unix) specifies a `ts-epoch'. The TIMESTAMP is
+  calculated as offset from the epoch returned by `ts-epoch'."
+  (let* ((base (ts-unix (ts-epoch epoch)))
+         (ts (pcase-exhaustive timestamp
+               ((pred stringp) (string-to-number timestamp))
+               ((pred numberp) timestamp)))
+         (seconds (pcase-exhaustive resolution
+                    ('second ts)
+                    ('milli (/ ts 1.0e3))
+                    ('nano (/ ts 1.0e6))
+                    ('pico (/ ts 1.0e9)))))
+    (make-ts :unix (+ base seconds))))
+
 (defsubst ts-reset (ts)
   "Return TS with all slots cleared except `unix'.
 Non-destructive.  The same as:


### PR DESCRIPTION
Introduce `ts-parse-timestamp` for constructing a TS from a timestamp. This is
useful for time calculations if the source is coming from external programs
which are often timestamps in various resolutions and from various epochs.