### PR TITLE
Add a function for parsing ISO-8601 date time strings

### DIFF
--- a/test/test.el
+++ b/test/test.el
@@ -418,6 +418,10 @@
                      (ts-unix)
                      (equal 1443070800.0)))))))
 
+(ert-deftest ts-parse-iso8601 ()
+  (let* ((iso8601-string "2015-09-24T00:00:00+00:00"))
+    (should (equal 1443070800.0 (ts-unix (ts-parse-iso8601 iso8601-string))))))
+
 ;;;;; Other
 
 (ert-deftest ts-apply ()

--- a/ts.el
+++ b/ts.el
@@ -367,6 +367,10 @@ not support timestamps that contain seconds."
       (_ (error "FILL must be `begin' or `end'")))
     (make-ts :second second :minute minute :hour hour :day day :month month :year year)))
 
+(defsubst ts-parse-iso8601 (iso-8601)
+  "Return timestamp object for an ISO-8601 date string."
+  (make-ts :unix (float-time (parse-iso8601-time-string iso-8601))))
+
 ;;;; Functions
 
 (cl-defun ts-apply (&rest args)


### PR DESCRIPTION
This is a currently draft.

The test fail in my time zone, so I'll rework on this after #8 is merged. I want to follow styles of other test cases.

Perhaps I'll have to implement `ts-parse-iso8601-fill` as well.