### PR TITLE
Correct author format

### DIFF
--- a/ts.el
+++ b/ts.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2018-2019 Adam Porter
 
-;; Author: Adam Porter <adam@alphapapa.net
+;; Author: Adam Porter <adam@alphapapa.net>
 ;; URL: http://github.com/alphapapa/ts.el
 ;; Version: 0.3-pre
 ;; Package-Requires: ((emacs "26.1") (dash "2.14.1") (s "1.12.0"))


### PR DESCRIPTION
Hi, this is a really stupid issue, but a recent change in lm-crack-address leads to a (wrong-type-argument stringp nil) error because a ">" is missing after your email.