### PR TITLE
Update internal to avoid precision destruction

### DIFF
--- a/test/test.el
+++ b/test/test.el
@@ -74,10 +74,25 @@
 (ert-deftest ts-tz-abbr ()
   (should (equal (ts-tz-abbr (ts-now))
                  (format-time-string "%Z"))))
+
+  ;; The next cases are anticipated to require an update if ts switches to
+  ;; (TICKS . HZ) as its implementation time.
+  ;; (should (let ((ts (ts-now)))
+  ;;           (equal (ts-internal ts)
+  ;;                  (time-convert (ts-unix ts) t))))
+  ;; (should (let* ((time (float-time))
+  ;;                (ts (ts-apply :unix time (ts-now))))
+  ;;           (equal (ts-internal ts)
+  ;;                  (time-convert time t))))
+
 (ert-deftest ts-unix ()
   ;; Theoretically this test could fail if run extremely close to a second boundary, but it's probably good enough.
   (should (equal (floor (ts-unix (ts-now)))
                  (string-to-number (format-time-string "%s")))))
+
+(ert-deftest ts-internal ()
+  (should (pcase (ts-internal (ts-now))
+            (`(,(pred integerp) . ,(pred integerp)) t))))
 
 ;;;;; Adjustors
 

--- a/ts.el
+++ b/ts.el
@@ -222,7 +222,7 @@ slot `year' and alias `y' would create an alias `ts-y')."
   ;; MAYBE: Add tz-offset-minutes
 
   (internal
-   nil :accessor-init (apply #'encode-time (decode-time (ts-unix struct))))
+   nil :accessor-init (time-convert (ts-unix struct) t))
   (unix
    nil :accessor-init (pcase-let* (((cl-struct ts second minute hour day month year) struct))
                         (if (and second minute hour day month year)


### PR DESCRIPTION
First things first regarding #25 

I noticed while writing a test that `#'ts-apply` and `#'ts-update'  were mutating the unix time even though it's unnecessary.

A proper fix started to rabbit hole a bit:
- If calling `ts-apply` with just a `:unix` time, there's no need to update the unix time again in `ts-update`.  Every other slot could update if non-nil, but the unix time should not
- There is no error when calls are made with both unix or internal and any combination of day, month etc, but these calls are surely an improper usage

The kinds of tests I was running and expecting to work:
```elisp
(let* ((time (float-time))
                 (ts (ts-apply :unix time (ts-now))))
     `(,(ts-internal ts)
       ,(time-convert time t)))
;;  ((7133786877722624 . 4194304)
;;   (7133786879364915 . 4194304))
```
`ts-update` is not taking the easy path...

Here's another test
```elisp
(let* ((time (time-convert (current-time) t))
                 (ts (ts-apply :internal time (ts-now))))
     `(,(ts-unix ts)
       ,(float-time time)))
     
(1700827572.0 1700827572.2982888)
```

Ah, so both times are actually truncating to seconds unnecessarily.  I can expand the scope of the PR if you think it's likely to pay off.